### PR TITLE
Fix signature deletion functionality

### DIFF
--- a/src/components/SignaturePad.tsx
+++ b/src/components/SignaturePad.tsx
@@ -6,7 +6,7 @@ import { useToast } from './ui/use-toast';
 import { Card } from './ui/card';
 
 interface SignaturePadProps {
-  onSave: (signature: string) => void;
+  onSave: (signature: string | null) => void;
   initialSignature?: string;
 }
 
@@ -20,6 +20,11 @@ export const SignaturePad = ({ onSave, initialSignature }: SignaturePadProps) =>
     if (signaturePad.current) {
       signaturePad.current.clear();
       setImagePreview(null);
+      onSave(null); // Pass null to remove signature from storage
+      toast({
+        title: "Unterschrift gelöscht",
+        description: "Ihre Unterschrift wurde erfolgreich gelöscht.",
+      });
     }
   };
 

--- a/src/lib/presetStorage.ts
+++ b/src/lib/presetStorage.ts
@@ -45,11 +45,10 @@ export const deletePreset = (id: string): void => {
 };
 
 export const saveSenderInfo = (info: string, ortRechnungssteller: string, signature?: string): void => {
-  const currentSettings = getSettings();
   localStorage.setItem(SETTINGS_KEY, JSON.stringify({ 
     senderInfo: info, 
     ortRechnungssteller,
-    signature: signature || currentSettings.signature
+    signature
   }));
 };
 

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -25,8 +25,8 @@ const Settings = () => {
     });
   };
 
-  const handleSaveSignature = (signature: string) => {
-    saveSenderInfo(senderInfo, ortRechnungssteller, signature);
+  const handleSaveSignature = (signature: string | null) => {
+    saveSenderInfo(senderInfo, ortRechnungssteller, signature || undefined);
     localStorage.setItem("settings-viewed", "true");
   };
 


### PR DESCRIPTION
Ensure that when the delete button is clicked, the signature is removed from both the UI and the generated PDF. [skip gpt_engineer]

fix issue #63 